### PR TITLE
feat!: expose set heap limits globally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marine-sqlite-connector"
-version = "0.7.0"
+version = "0.8.0"
 license = "Apache-2.0/MIT"
 authors = [
     "Daniel Dulaney <ddy@vitronic.com>",
@@ -37,7 +37,9 @@ path = "src/test.rs"
 
 [dependencies]
 marine-rs-sdk = "0.7.0"
+bytesize = "1.2.0"
 
 [dev-dependencies]
-temporary = "0.6"
 marine-rs-sdk-test = "0.2.0"
+temporary = "0.6"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,3 @@ bytesize = "1.2.0"
 [dev-dependencies]
 marine-rs-sdk-test = "0.2.0"
 temporary = "0.6"
-

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -90,7 +90,6 @@ impl Connection {
     /// Create a prepared statement.
     #[inline]
     pub fn prepare<T: AsRef<str>>(&self, statement: T) -> Result<Statement> {
-    pub fn prepare<T: AsRef<str>>(&self, statement: T) -> Result<Statement> {
         crate::statement::new(self.raw, statement)
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -55,10 +55,6 @@ impl Connection {
         }
     }
 
-    pub fn set_memory_limit(limit: i64) -> i64 {
-        unsafe { ffi::sqlite3_hard_heap_limit64(limit) }
-    }
-
     /// Execute a statement without processing the resulting rows if any.
     #[inline]
     pub fn execute<T: AsRef<str>>(&self, statement: T) -> Result<()> {
@@ -93,6 +89,7 @@ impl Connection {
 
     /// Create a prepared statement.
     #[inline]
+    pub fn prepare<T: AsRef<str>>(&self, statement: T) -> Result<Statement> {
     pub fn prepare<T: AsRef<str>>(&self, statement: T) -> Result<Statement> {
         crate::statement::new(self.raw, statement)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,3 +304,24 @@ fn last_error(raw: ffi::Sqlite3DbHandle) -> Option<Error> {
         })
     }
 }
+
+/// From the SQLite docs:
+///
+/// The sqlite3_soft_heap_limit64() interface sets and/or queries the soft limit on the amount of
+/// heap memory that may be allocated by SQLite. SQLite strives to keep heap memory utilization
+/// below the soft heap limit by reducing the number of pages held in the page cache as heap memory
+/// usages approaches the limit. The soft heap limit is "soft" because even though SQLite strives
+/// to stay below the limit, it will exceed the limit rather than generate an SQLITE_NOMEM error.
+/// In other words, the soft heap limit is advisory only.
+pub fn soft_heap_limit64(limit: i64) -> i64 {
+    unsafe { ffi::sqlite3_hard_heap_limit64(limit) }
+}
+
+/// From the SQLite docs:
+///
+/// This interface sets a hard upper bound of N bytes on the amount of memory that will be
+/// allocated. The set_hard_heap_limit64 interface is similar to soft_heap_limit64
+/// except that memory allocations will fail when the hard heap limit is reached.
+pub fn set_hard_heap_limit64(limit: i64) -> i64 {
+    unsafe { ffi::sqlite3_hard_heap_limit64(limit) }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ fn last_error(raw: ffi::Sqlite3DbHandle) -> Option<Error> {
 /// usages approaches the limit. The soft heap limit is "soft" because even though SQLite strives
 /// to stay below the limit, it will exceed the limit rather than generate an SQLITE_NOMEM error.
 /// In other words, the soft heap limit is advisory only.
-pub fn soft_heap_limit64(limit: i64) -> i64 {
+pub fn soft_soft_heap_limit64(limit: i64) -> i64 {
     unsafe { ffi::sqlite3_hard_heap_limit64(limit) }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,7 @@ fn last_error(raw: ffi::Sqlite3DbHandle) -> Option<Error> {
 /// to stay below the limit, it will exceed the limit rather than generate an SQLITE_NOMEM error.
 /// In other words, the soft heap limit is advisory only.
 pub fn soft_soft_heap_limit64(limit: i64) -> i64 {
-    unsafe { ffi::sqlite3_hard_heap_limit64(limit) }
+    unsafe { ffi::sqlite3_soft_heap_limit64(limit) }
 }
 
 /// From the SQLite docs:

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -76,4 +76,9 @@ mod tests {
     fn test12(test: marine_test_env::test::ModuleInterface) {
         test.test12()
     }
+
+    #[marine_test(config_path = "../Config.toml", modules_dir = "../artifacts/")]
+    fn test13(test: marine_test_env::test::ModuleInterface) {
+        test.test13()
+    }
 }


### PR DESCRIPTION
At the moment `soft_heap_limit64` is exported from `Connection`, although it doesn't really belong to `Connection` since it sets limit globally for SQLite instance, not as per connection.